### PR TITLE
earlephilhower/aquaweb#6:int object is not iterable toHex

### DIFF
--- a/aquaweb.py
+++ b/aquaweb.py
@@ -649,7 +649,12 @@ def log(*args):
 
 def toHex(blist):
     """Simple convert list of ints to a HEX string"""
-    return ''.join(format(x, "02x") for x in blist)
+    if isinstance(blist, list):
+       return ''.join(format(x, "02x") for x in blist)
+    elif isinstance(blist, int):
+       return format(blist, "02x")
+    else:
+       return ''
 
 class Interface:
     """ Aqualink serial interface """


### PR DESCRIPTION
After this fix I see the following

```
pi@raspberrypi:~/git/aquaweb $ ./aquaweb.py
Creating RS485 port...
RS485           : ready
Attempting to auto-detect emulation settings, wait 15 seconds...
...Detected new-style Aqualink PDA.
Detection completed...
Creating PDA emulator...
Creating web server...
Main loop begins...
Started httpserver on port 8080
unk: cmd=1b args=0000
unk: cmd=1b args=0100
^CKeyboard exit requested.
```

